### PR TITLE
Add StartupWMClass (groups Okular instances on Gnome)

### DIFF
--- a/generators/poppler/okularApplication_pdf.desktop
+++ b/generators/poppler/okularApplication_pdf.desktop
@@ -217,3 +217,4 @@ X-KDE-Keywords[x-test]=xxPDFxx,xx Portable Document Formatxx
 X-KDE-Keywords[zh_CN]=PDF, Portable Document Format,开放文档格式
 X-KDE-Keywords[zh_TW]=PDF, Portable Document Format
 NoDisplay=true
+StartupWMClass=okular


### PR DESCRIPTION
Ordinarily Gnome groups windows by application. Without this class, Gnome can't tell that Okular windows should be grouped and so they show up individually, cluttering the alt-tab dialog and the "Dash" (dock). This fix should be added to all Okular's .desktop files.