### PR TITLE
Add experimental Dark Reader mode for PDF documents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,9 +217,21 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 find_package(ZLIB REQUIRED)
 
-find_package(Poppler "24.08.0" COMPONENTS Qt6)
+find_package(Poppler "24.08.0" COMPONENTS Qt6 OPTIONAL_COMPONENTS Core)
 set_okular_optional_package_properties(Poppler PROPERTIES
         PURPOSE "Support for PDF files in okular.")
+
+# The Poppler::Core component (i.e. libpoppler itself, as opposed to the
+# poppler-qt6 wrapper) is optional: it is only used by the PDF generator to
+# implement the exact, provenance-based image mask for the Dark Reader
+# feature (see generators/poppler/darkreaderoutputdev.h). When unavailable,
+# Dark Reader still works, but falls back to recoloring embedded images along
+# with text/background instead of excluding them.
+if (TARGET Poppler::Core)
+    add_definitions(-DHAVE_POPPLER_CORE_OUTPUTDEV=1)
+else()
+    add_definitions(-DHAVE_POPPLER_CORE_OUTPUTDEV=0)
+endif()
 
 find_package(Freetype)
 set_okular_optional_package_properties(Freetype PROPERTIES

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Okular – Universal Document Viewer
+# Experimental Feature: Dark reader [Demo](https://youtu.be/Xf0qtwL_RVU)
+## Features: 
+1. Inverts text without inverting images
+2. provides a shortcut to toggle dark reader
+3. option to choose dark reader background from default(breeze background), color scheme or Custom
+4. text's luminosity is changed so they preserve colors ( unlike color mode: change light and dark color
+
 
 Okular can view and annotate documents of various formats, including PDF, Postscript, Comic Book, and various image formats.
 It supports native PDF annotations.

--- a/autotests/darkreadermanualtest.cpp
+++ b/autotests/darkreadermanualtest.cpp
@@ -1,0 +1,87 @@
+/*
+    Throwaway manual validation harness for the Dark Reader exact image mask
+    feature. Not wired into CMakeLists.txt; compiled and run manually during
+    development. Loads a real PDF, renders it once with normal colors and
+    once with Dark Reader enabled, and writes both out as PNGs for visual
+    inspection.
+*/
+
+#include <QApplication>
+#include <QDebug>
+#include <QImage>
+#include <QPainter>
+
+#include "core/document.h"
+#include "core/generator.h"
+#include "core/observer.h"
+#include "core/page.h"
+#include "gui/pagepainter.h"
+#include "settings_core.h"
+
+class DummyObserver : public Okular::DocumentObserver
+{
+public:
+    void notifyPageChanged(int, int) override
+    {
+    }
+};
+
+int main(int argc, char **argv)
+{
+    QApplication app(argc, argv);
+
+    if (argc < 3) {
+        qWarning() << "usage:" << argv[0] << "file.pdf out_prefix";
+        return 1;
+    }
+
+    const QString filePath = QString::fromLocal8Bit(argv[1]);
+    const QString outPrefix = QString::fromLocal8Bit(argv[2]);
+
+    DummyObserver observer;
+    Okular::Document doc(nullptr);
+    doc.addObserver(&observer);
+
+    const Okular::Document::OpenResult r = doc.openDocument(filePath, QUrl::fromLocalFile(filePath), QMimeType());
+    if (r != Okular::Document::OpenSuccess) {
+        qWarning() << "failed to open" << filePath << (int)r;
+        return 1;
+    }
+
+    if (doc.pages() < 1) {
+        qWarning() << "no pages";
+        return 1;
+    }
+
+    Okular::Page *page = doc.page(0);
+    const int w = 1000;
+    const int h = qRound(1000.0 * page->height() / page->width());
+
+    auto renderAndSave = [&](const QString &suffix) {
+        Okular::PixmapRequest *req = new Okular::PixmapRequest(&observer, 0, w, h, 1.0, 1, Okular::PixmapRequest::NoFeature);
+        doc.requestPixmaps({req});
+
+        // With EnableThreading disabled, rendering happens synchronously
+        // inside requestPixmaps(), so the pixmap is already attached to the
+        // page by the time we get here.
+        QImage img(w, h, QImage::Format_ARGB32_Premultiplied);
+        QPainter p(&img);
+        PagePainter::paintPageOnPainter(&p, page, &observer, PagePainter::Accessibility, w, h, QRect(0, 0, w, h));
+        p.end();
+
+        const QString outPath = outPrefix + suffix + QStringLiteral(".png");
+        img.save(outPath);
+        qDebug() << "wrote" << outPath;
+    };
+
+    Okular::SettingsCore::setEnableThreading(false);
+
+    Okular::SettingsCore::setChangeColors(false);
+    renderAndSave(QStringLiteral("_normal"));
+
+    Okular::SettingsCore::setRenderMode(Okular::SettingsCore::EnumRenderMode::DarkReader);
+    Okular::SettingsCore::setChangeColors(true);
+    renderAndSave(QStringLiteral("_darkreader"));
+
+    return 0;
+}

--- a/conf/okular.kcfg
+++ b/conf/okular.kcfg
@@ -410,6 +410,19 @@
    <default code="true" >0xF0F0F0</default>
    <emit signal="colorModesChanged2" />
   </entry>
+  <entry key="DarkReaderBackgroundMode" type="Enum" >
+   <default>Default</default>
+   <choices>
+    <choice name="Default" />
+    <choice name="ColorScheme" />
+    <choice name="Custom" />
+   </choices>
+   <emit signal="colorModesChanged2" />
+  </entry>
+  <entry key="DarkReaderCustomBackgroundColor" type="Color" >
+   <default code="true" >0x232627</default>
+   <emit signal="colorModesChanged2" />
+  </entry>
   <entry key="BWThreshold" type="UInt" >
    <default>127</default>
    <min>2</min>

--- a/conf/okular_core.kcfg
+++ b/conf/okular_core.kcfg
@@ -62,6 +62,7 @@
     <choice name="InvertLumaSymmetric" />
     <choice name="HueShiftPositive" />
     <choice name="HueShiftNegative" />
+    <choice name="DarkReader" />
    </choices>
    <emit signal="colorModesChanged" />
   </entry>

--- a/core/page_p.h
+++ b/core/page_p.h
@@ -60,7 +60,7 @@ public:
     PagePrivate(Page *page, uint n, double w, double h, Rotation o);
     ~PagePrivate();
 
-    static PagePrivate *get(Page *page);
+    OKULARCORE_EXPORT static PagePrivate *get(Page *page);
 
     void imageRotationDone(RotationJob *job);
     QTransform rotationMatrix() const;

--- a/generators/poppler/CMakeLists.txt
+++ b/generators/poppler/CMakeLists.txt
@@ -30,6 +30,12 @@ okular_add_generator(okularGenerator_poppler ${okularGenerator_poppler_PART_SRCS
 
 target_link_libraries(okularGenerator_poppler okularcore KF6::I18n KF6::Completion KF6::KIOWidgets Poppler::Qt6 Qt6::Xml)
 
+# See the HAVE_POPPLER_CORE_OUTPUTDEV definition in the top-level CMakeLists.txt.
+if (TARGET Poppler::Core)
+    target_sources(okularGenerator_poppler PRIVATE darkreaderoutputdev.cpp)
+    target_link_libraries(okularGenerator_poppler Poppler::Core)
+endif()
+
 ########### autotests ###############
 
 if(BUILD_TESTING)

--- a/generators/poppler/annots.cpp
+++ b/generators/poppler/annots.cpp
@@ -69,10 +69,11 @@ static int maskExportedFlags(int flags)
 }
 
 // BEGIN PopplerAnnotationProxy implementation
-PopplerAnnotationProxy::PopplerAnnotationProxy(Poppler::Document *doc, QMutex *userMutex, QHash<Okular::Annotation *, Poppler::Annotation *> *annotsOnOpenHash)
+PopplerAnnotationProxy::PopplerAnnotationProxy(Poppler::Document *doc, QMutex *userMutex, QHash<Okular::Annotation *, Poppler::Annotation *> *annotsOnOpenHash, QSet<int> *pagesWithUnsavedAnnotations)
     : ppl_doc(doc)
     , mutex(userMutex)
     , annotationsOnOpenHash(annotsOnOpenHash)
+    , m_pagesWithUnsavedAnnotations(pagesWithUnsavedAnnotations)
 {
 }
 
@@ -613,6 +614,10 @@ void PopplerAnnotationProxy::notifyAddition(Okular::Annotation *okl_ann, int pag
 {
     QMutexLocker ml(mutex);
 
+    if (m_pagesWithUnsavedAnnotations) {
+        m_pagesWithUnsavedAnnotations->insert(page);
+    }
+
     std::unique_ptr<Poppler::Page> ppl_page = ppl_doc->page(page);
 
     // Create poppler annotation
@@ -685,7 +690,6 @@ void PopplerAnnotationProxy::notifyAddition(Okular::Annotation *okl_ann, int pag
 
 void PopplerAnnotationProxy::notifyModification(const Okular::Annotation *okl_ann, int page, bool appearanceChanged)
 {
-    Q_UNUSED(page);
     Q_UNUSED(appearanceChanged);
 
     Poppler::Annotation *ppl_ann = qvariant_cast<Poppler::Annotation *>(okl_ann->nativeId());
@@ -695,6 +699,10 @@ void PopplerAnnotationProxy::notifyModification(const Okular::Annotation *okl_an
     }
 
     QMutexLocker ml(mutex);
+
+    if (m_pagesWithUnsavedAnnotations) {
+        m_pagesWithUnsavedAnnotations->insert(page);
+    }
 
     if (okl_ann->flags() & (Okular::Annotation::BeingMoved | Okular::Annotation::BeingResized)) {
         // Okular ui already renders the annotation on its own
@@ -791,6 +799,10 @@ void PopplerAnnotationProxy::notifyRemoval(Okular::Annotation *okl_ann, int page
     }
 
     QMutexLocker ml(mutex);
+
+    if (m_pagesWithUnsavedAnnotations) {
+        m_pagesWithUnsavedAnnotations->insert(page);
+    }
 
     std::unique_ptr<Poppler::Page> ppl_page = ppl_doc->page(page);
     annotationsOnOpenHash->remove(okl_ann);

--- a/generators/poppler/annots.h
+++ b/generators/poppler/annots.h
@@ -15,6 +15,7 @@
 #include <poppler-version.h>
 
 #include <QMutex>
+#include <QSet>
 
 #include <unordered_map>
 
@@ -25,7 +26,7 @@ extern Okular::Annotation *createAnnotationFromPopplerAnnotation(Poppler::Annota
 class PopplerAnnotationProxy : public Okular::AnnotationProxy
 {
 public:
-    PopplerAnnotationProxy(Poppler::Document *doc, QMutex *userMutex, QHash<Okular::Annotation *, Poppler::Annotation *> *annotsOnOpenHash);
+    PopplerAnnotationProxy(Poppler::Document *doc, QMutex *userMutex, QHash<Okular::Annotation *, Poppler::Annotation *> *annotsOnOpenHash, QSet<int> *pagesWithUnsavedAnnotations = nullptr);
     ~PopplerAnnotationProxy() override;
 
     bool supports(Capability capability) const override;
@@ -37,6 +38,7 @@ private:
     Poppler::Document *ppl_doc;
     QMutex *mutex;
     QHash<Okular::Annotation *, Poppler::Annotation *> *annotationsOnOpenHash;
+    QSet<int> *m_pagesWithUnsavedAnnotations;
     std::unordered_map<Okular::StampAnnotation *, std::unique_ptr<Poppler::AnnotationAppearance>> deletedStampsAnnotationAppearance;
 };
 

--- a/generators/poppler/darkreaderoutputdev.cpp
+++ b/generators/poppler/darkreaderoutputdev.cpp
@@ -1,0 +1,243 @@
+/*
+    SPDX-FileCopyrightText: 2026 Okular contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "darkreaderoutputdev.h"
+
+#include <GfxState.h>
+#include <GlobalParams.h>
+#include <Object.h>
+#include <PDFDoc.h>
+#include <SplashOutputDev.h>
+#include <Stream.h>
+#include <goo/GooString.h>
+#include <splash/SplashBitmap.h>
+
+#include <QSysInfo>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+
+/**
+ * A SplashOutputDev that, alongside normal Splash rendering, records the
+ * device-pixel bounding box of every image-drawing operation into a
+ * grayscale mask.
+ *
+ * Note that setSoftMaskFromImageMask()/unsetSoftMaskFromImageMask() are
+ * deliberately NOT overridden here: those calls only install/clear a soft
+ * mask used to clip *subsequent* fill operations (a common technique for
+ * drawing anti-aliased or gradient-clipped vector shapes), they do not by
+ * themselves paint an image. Pixels painted while such a soft mask is
+ * active go through Splash's normal fill/stroke path, not through one of
+ * the drawImage* overrides below, so they are correctly left out of the
+ * mask and remain eligible for recoloring like any other vector content.
+ *
+ * Nested Form XObjects (images inside forms inside forms) need no special
+ * handling: Poppler's own content-stream interpreter (Gfx::doForm())
+ * recurses into forms and invokes these same overridden methods for
+ * whatever they draw, regardless of nesting depth.
+ */
+class MaskingSplashOutputDev : public SplashOutputDev
+{
+public:
+    MaskingSplashOutputDev(SplashColorMode colorModeA, int bitmapRowPadA, bool reverseVideoA, SplashColorPtr paperColorA, bool bitmapTopDownA, SplashThinLineMode thinLineModeA)
+        : SplashOutputDev(colorModeA, bitmapRowPadA, reverseVideoA, paperColorA, bitmapTopDownA, thinLineModeA)
+    {
+    }
+
+    void startPage(int pageNum, GfxState *state, XRef *xrefA) override
+    {
+        SplashOutputDev::startPage(pageNum, state, xrefA);
+
+        // The bitmap size is only known once the base class has set up the
+        // page, so the mask is (re)created here rather than in the
+        // constructor.
+        maskImage = QImage(getBitmapWidth(), getBitmapHeight(), QImage::Format_Grayscale8);
+        maskImage.fill(0);
+    }
+
+    void drawImageMask(GfxState *state, Object *ref, Stream *str, int width, int height, bool invert, bool interpolate, bool inlineImg) override
+    {
+        SplashOutputDev::drawImageMask(state, ref, str, width, height, invert, interpolate, inlineImg);
+        markImageRegion(state);
+    }
+
+    void drawImage(GfxState *state, Object *ref, Stream *str, int width, int height, GfxImageColorMap *colorMap, bool interpolate, const int *maskColors, bool inlineImg) override
+    {
+        SplashOutputDev::drawImage(state, ref, str, width, height, colorMap, interpolate, maskColors, inlineImg);
+        markImageRegion(state);
+    }
+
+    void drawMaskedImage(GfxState *state, Object *ref, Stream *str, int width, int height, GfxImageColorMap *colorMap, bool interpolate, Stream *maskStr, int maskWidth, int maskHeight, bool maskInvert, bool maskInterpolate) override
+    {
+        SplashOutputDev::drawMaskedImage(state, ref, str, width, height, colorMap, interpolate, maskStr, maskWidth, maskHeight, maskInvert, maskInterpolate);
+        markImageRegion(state);
+    }
+
+    void drawSoftMaskedImage(GfxState *state,
+                             Object *ref,
+                             Stream *str,
+                             int width,
+                             int height,
+                             GfxImageColorMap *colorMap,
+                             bool interpolate,
+                             Stream *maskStr,
+                             int maskWidth,
+                             int maskHeight,
+                             GfxImageColorMap *maskColorMap,
+                             bool maskInterpolate) override
+    {
+        SplashOutputDev::drawSoftMaskedImage(state, ref, str, width, height, colorMap, interpolate, maskStr, maskWidth, maskHeight, maskColorMap, maskInterpolate);
+        markImageRegion(state);
+    }
+
+    QImage maskImage;
+
+private:
+    void markImageRegion(GfxState *state)
+    {
+        if (maskImage.isNull()) {
+            return;
+        }
+
+        // Images are always painted into the unit square in user space;
+        // map its four corners through the CTM to find the device-pixel
+        // bounding box actually covered by this draw call. A bounding box
+        // (rather than exact per-pixel coverage, which would require
+        // re-deriving Splash's own clipping/sampling) is used deliberately:
+        // it is much cheaper to compute, and for the purpose of excluding
+        // images from recoloring, slightly over-including a sliver of
+        // background around a rotated/skewed image is an acceptable
+        // trade-off.
+        double xs[4];
+        double ys[4];
+        state->transform(0, 0, &xs[0], &ys[0]);
+        state->transform(1, 0, &xs[1], &ys[1]);
+        state->transform(0, 1, &xs[2], &ys[2]);
+        state->transform(1, 1, &xs[3], &ys[3]);
+
+        const double xMin = *std::min_element(xs, xs + 4);
+        const double xMax = *std::max_element(xs, xs + 4);
+        const double yMin = *std::min_element(ys, ys + 4);
+        const double yMax = *std::max_element(ys, ys + 4);
+
+        const int ixMin = std::clamp(static_cast<int>(std::floor(xMin)), 0, maskImage.width());
+        const int ixMax = std::clamp(static_cast<int>(std::ceil(xMax)), 0, maskImage.width());
+        const int iyMin = std::clamp(static_cast<int>(std::floor(yMin)), 0, maskImage.height());
+        const int iyMax = std::clamp(static_cast<int>(std::ceil(yMax)), 0, maskImage.height());
+
+        for (int y = iyMin; y < iyMax; ++y) {
+            uchar *row = maskImage.scanLine(y);
+            std::fill(row + ixMin, row + ixMax, uchar(255));
+        }
+    }
+};
+
+}
+
+std::unique_ptr<DarkReaderRenderer> DarkReaderRenderer::create(const QString &filePath)
+{
+    if (filePath.isEmpty()) {
+        return nullptr;
+    }
+
+    // Poppler's core API requires the process-wide globalParams to be
+    // initialized. Poppler::Document::load() (used for the primary,
+    // poppler-qt6-backed document) already initializes it as a side effect,
+    // and that always happens before a PDF can be displayed at all, so by
+    // the time Dark Reader can be toggled on for a document, globalParams is
+    // guaranteed to already exist. This check is a defensive fallback, not
+    // the "normal" way globalParams is expected to get set up.
+    if (!globalParams) {
+        return nullptr;
+    }
+
+    auto doc = std::make_unique<PDFDoc>(std::make_unique<GooString>(filePath.toUtf8().constData()));
+    if (!doc->isOk()) {
+        return nullptr;
+    }
+    if (doc->isEncrypted()) {
+        // See the class documentation: password-protected documents are
+        // deliberately unsupported for this feature.
+        return nullptr;
+    }
+
+    return std::unique_ptr<DarkReaderRenderer>(new DarkReaderRenderer(std::move(doc)));
+}
+
+DarkReaderRenderer::DarkReaderRenderer(std::unique_ptr<PDFDoc> doc)
+    : m_doc(std::move(doc))
+{
+}
+
+DarkReaderRenderer::~DarkReaderRenderer() = default;
+
+bool DarkReaderRenderer::render(int pageNumber, double dpiX, double dpiY, QImage *outImage, QImage *outMask)
+{
+    if (!m_doc || !outImage || !outMask) {
+        return false;
+    }
+    if (pageNumber < 0 || pageNumber >= m_doc->getNumPages()) {
+        return false;
+    }
+
+    SplashColor paperColor;
+    paperColor[0] = 255;
+    paperColor[1] = 255;
+    paperColor[2] = 255;
+
+    // splashModeXBGR8 plus the QImage::Format_RGB32 conversion below mirrors
+    // exactly what poppler-qt6's Page::renderToImage() does internally for
+    // the (default) opaque, non-overprint-preview case (see
+    // Qt6SplashOutputDev::getXBGRImage() in poppler's qt6/src/poppler-page.cc),
+    // so the bitmap this produces is pixel-for-pixel equivalent to what the
+    // normal (non-Dark-Reader) rendering path would have produced for the
+    // same page and resolution.
+    MaskingSplashOutputDev out(splashModeXBGR8, 4, false, paperColor, true, splashThinLineDefault);
+    out.startDoc(m_doc.get());
+    out.setFontAntialias(true);
+    out.setVectorAntialias(true);
+
+    // Poppler page numbers for displayPageSlice() are 1-based. Rotation is
+    // always 0 here: Okular applies view rotation itself, uniformly across
+    // all generators, as a separate step performed on the returned bitmap;
+    // the mask must be produced in the same unrotated orientation so it
+    // still lines up after that step is applied.
+    m_doc->displayPageSlice(&out, pageNumber + 1, dpiX, dpiY, 0, false, true, false, -1, -1, -1, -1);
+
+    SplashBitmap *bitmap = out.getBitmap();
+    if (!bitmap || !bitmap->convertToXBGR(SplashBitmap::conversionOpaque)) {
+        return false;
+    }
+
+    const int w = bitmap->getWidth();
+    const int h = bitmap->getHeight();
+    const int rowSize = bitmap->getRowSize();
+
+    if (QSysInfo::ByteOrder == QSysInfo::BigEndian) {
+        // Convert byte order from RGBX to XBGR, matching poppler-qt6.
+        SplashColorPtr data = bitmap->getDataPtr();
+        for (int i = 0; i < h; ++i) {
+            for (int j = 0; j < w; ++j) {
+                SplashColorPtr pixel = &data[i * rowSize + j];
+                std::swap(pixel[0], pixel[3]);
+                std::swap(pixel[1], pixel[2]);
+            }
+        }
+    }
+
+    // Copy (rather than take ownership of) the Splash buffer: entangling
+    // QImage's allocator expectations with Splash's own buffer lifetime is
+    // not worth it here, since this runs once per zoom/rotation change or
+    // Dark Reader toggle, not on every repaint.
+    const QImage img(bitmap->getDataPtr(), w, h, rowSize, QImage::Format_RGB32);
+    *outImage = img.copy();
+    *outMask = out.maskImage;
+
+    return !outImage->isNull() && !outMask->isNull();
+}

--- a/generators/poppler/darkreaderoutputdev.h
+++ b/generators/poppler/darkreaderoutputdev.h
@@ -1,0 +1,87 @@
+/*
+    SPDX-FileCopyrightText: 2026 Okular contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef OKULAR_GENERATOR_PDF_DARKREADEROUTPUTDEV_H
+#define OKULAR_GENERATOR_PDF_DARKREADEROUTPUTDEV_H
+
+#include <QImage>
+#include <QString>
+
+#include <memory>
+
+class PDFDoc;
+
+/**
+ * Renders a PDF page through a custom Poppler SplashOutputDev subclass that,
+ * in addition to producing the normal page bitmap, records exactly which
+ * device pixels were painted by an image-drawing operator (drawImage,
+ * drawImageMask, drawMaskedImage, drawSoftMaskedImage). This provides an
+ * exact, draw-call-provenance-based "is this pixel part of an embedded
+ * raster image" mask for the Dark Reader feature, replacing the previous
+ * per-pixel color heuristic.
+ *
+ * Both the bitmap and the mask are produced from a SINGLE render pass.
+ *
+ * This requires driving the render through Poppler's core (non-Qt) API
+ * directly: Poppler::Page / Poppler::Document (the Qt wrapper Okular
+ * otherwise uses everywhere else in this generator) do not expose the
+ * underlying core Page and PDFDoc objects needed to install a custom
+ * OutputDev. See DarkReaderRenderer::create() for how a secondary, read-only
+ * PDFDoc is opened for this sole purpose, and generator_pdf.cpp for the
+ * constraints under which it is used (PDF documents without a password,
+ * loaded from a local file path).
+ *
+ * Only compiled when Okular was built against Poppler's core library
+ * headers in addition to poppler-qt6; see HAVE_POPPLER_CORE_OUTPUTDEV.
+ */
+class DarkReaderRenderer
+{
+public:
+    /**
+     * Opens a secondary, independent PDFDoc for @p filePath, used only to
+     * drive mask-generating renders for the Dark Reader feature.
+     *
+     * Returns nullptr if the document could not be opened, or is
+     * password-protected. Password-protected documents are deliberately
+     * unsupported here: Okular does not retain the plaintext password after
+     * unlocking the primary document (to avoid keeping it in memory for the
+     * life of the document), so there would be nothing to unlock a second,
+     * independent PDFDoc with.
+     */
+    static std::unique_ptr<DarkReaderRenderer> create(const QString &filePath);
+
+    ~DarkReaderRenderer();
+
+    DarkReaderRenderer(const DarkReaderRenderer &) = delete;
+    DarkReaderRenderer &operator=(const DarkReaderRenderer &) = delete;
+
+    /**
+     * Renders page @p pageNumber (0-based) at the given resolution, writing
+     * the resulting page bitmap to @p outImage (pixel-for-pixel equivalent
+     * to what Poppler::Page::renderToImage() would produce for the same
+     * page/resolution) and the corresponding "exclude from recoloring" mask
+     * to @p outMask (Format_Grayscale8, 255 = image pixel, 0 = text/background
+     * pixel).
+     *
+     * The page is always rendered unrotated (rotate=0); Okular applies view
+     * rotation as a separate step of its own for all generators, and the
+     * mask must line up with the unrotated bitmap the same way the normal
+     * render path does.
+     *
+     * Returns false if rendering failed for any reason, in which case the
+     * caller should fall back to the normal renderToImage() path (and, for
+     * the Dark Reader feature specifically, to recoloring the whole page
+     * without excluding images).
+     */
+    bool render(int pageNumber, double dpiX, double dpiY, QImage *outImage, QImage *outMask);
+
+private:
+    explicit DarkReaderRenderer(std::unique_ptr<PDFDoc> doc);
+
+    std::unique_ptr<PDFDoc> m_doc;
+};
+
+#endif

--- a/generators/poppler/generator_pdf.cpp
+++ b/generators/poppler/generator_pdf.cpp
@@ -58,6 +58,7 @@
 #include "annots.h"
 #include "debug_pdf.h"
 #include "formfields.h"
+#include "settings_core.h"
 #include "imagescaling.h"
 #include "pdfsettingswidget.h"
 #include "pdfsignatureutils.h"
@@ -871,6 +872,11 @@ bool PDFGenerator::doCloseDocument()
     nextFontPage = 0;
     rectsGenerated.clear();
 
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+    m_darkReaderRenderer.reset();
+    m_darkReaderMaskCache.clear();
+#endif
+
     return true;
 }
 
@@ -1319,23 +1325,41 @@ QImage PDFGenerator::image(Okular::PixmapRequest *request)
     // 2. Take data from outputdev and attach it to the Page
     QImage img;
     if (p) {
-        if (request->isTile()) {
-            const QRect rect = request->normalizedRect().geometry(request->width(), request->height());
-            if (request->partialUpdatesWanted()) {
-                RenderImagePayload payload(this, request);
-                img = p->renderToImage(
-                    fakeDpiX, fakeDpiY, rect.x(), rect.y(), rect.width(), rect.height(), Poppler::Page::Rotate0, partialUpdateCallback, shouldDoPartialUpdateCallback, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+        bool renderedWithDarkReaderMask = false;
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+        // Dark Reader wants an exact "this pixel belongs to an embedded
+        // image" mask, so it can recolor everything else without touching
+        // photos. Producing that mask requires driving the render through
+        // Poppler's core API directly (see darkreaderoutputdev.h).
+        //
+        // We call ensureDarkReaderMask unconditionally when Dark Reader is active so that
+        // the mask cache is primed even if the current request is a tile or partial update
+        // request (which cannot directly reuse the full-page bitmap). This avoids the bug
+        // where images are incorrectly inverted on the first page paint until a zoom action occurs.
+        if (Okular::SettingsCore::changeColors() && Okular::SettingsCore::renderMode() == Okular::SettingsCore::EnumRenderMode::DarkReader) {
+            ensureDarkReaderMask(page, fakeDpiX, fakeDpiY);
+            renderedWithDarkReaderMask = renderWithDarkReaderMask(request, fakeDpiX, fakeDpiY, &img);
+        }
+#endif
+        if (!renderedWithDarkReaderMask) {
+            if (request->isTile()) {
+                const QRect rect = request->normalizedRect().geometry(request->width(), request->height());
+                if (request->partialUpdatesWanted()) {
+                    RenderImagePayload payload(this, request);
+                    img = p->renderToImage(
+                        fakeDpiX, fakeDpiY, rect.x(), rect.y(), rect.width(), rect.height(), Poppler::Page::Rotate0, partialUpdateCallback, shouldDoPartialUpdateCallback, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+                } else {
+                    RenderImagePayload payload(this, request);
+                    img = p->renderToImage(fakeDpiX, fakeDpiY, rect.x(), rect.y(), rect.width(), rect.height(), Poppler::Page::Rotate0, nullptr, nullptr, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+                }
             } else {
-                RenderImagePayload payload(this, request);
-                img = p->renderToImage(fakeDpiX, fakeDpiY, rect.x(), rect.y(), rect.width(), rect.height(), Poppler::Page::Rotate0, nullptr, nullptr, shouldAbortRenderCallback, QVariant::fromValue(&payload));
-            }
-        } else {
-            if (request->partialUpdatesWanted()) {
-                RenderImagePayload payload(this, request);
-                img = p->renderToImage(fakeDpiX, fakeDpiY, -1, -1, -1, -1, Poppler::Page::Rotate0, partialUpdateCallback, shouldDoPartialUpdateCallback, shouldAbortRenderCallback, QVariant::fromValue(&payload));
-            } else {
-                RenderImagePayload payload(this, request);
-                img = p->renderToImage(fakeDpiX, fakeDpiY, -1, -1, -1, -1, Poppler::Page::Rotate0, nullptr, nullptr, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+                if (request->partialUpdatesWanted()) {
+                    RenderImagePayload payload(this, request);
+                    img = p->renderToImage(fakeDpiX, fakeDpiY, -1, -1, -1, -1, Poppler::Page::Rotate0, partialUpdateCallback, shouldDoPartialUpdateCallback, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+                } else {
+                    RenderImagePayload payload(this, request);
+                    img = p->renderToImage(fakeDpiX, fakeDpiY, -1, -1, -1, -1, Poppler::Page::Rotate0, nullptr, nullptr, shouldAbortRenderCallback, QVariant::fromValue(&payload));
+                }
             }
         }
     } else {
@@ -1358,6 +1382,77 @@ QImage PDFGenerator::image(Okular::PixmapRequest *request)
 
     return img;
 }
+
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+void PDFGenerator::ensureDarkReaderMask(const Okular::Page *page, double dpiX, double dpiY)
+{
+    const int pageNum = page->number();
+    const auto it = m_darkReaderMaskCache.constFind(pageNum);
+    if (it != m_darkReaderMaskCache.constEnd() && it.value().dpiX == dpiX && it.value().dpiY == dpiY) {
+        return;
+    }
+
+    if (documentHasPassword || documentFilePath.isEmpty()) {
+        return;
+    }
+
+    if (!m_darkReaderRenderer) {
+        m_darkReaderRenderer = DarkReaderRenderer::create(documentFilePath);
+    }
+    if (!m_darkReaderRenderer) {
+        return;
+    }
+
+    QImage img;
+    QImage mask;
+    if (!m_darkReaderRenderer->render(pageNum, dpiX, dpiY, &img, &mask)) {
+        m_darkReaderRenderer.reset();
+        m_darkReaderMaskCache.remove(pageNum);
+        return;
+    }
+
+    DarkReaderMaskEntry entry;
+    entry.mask = mask;
+    entry.dpiX = dpiX;
+    entry.dpiY = dpiY;
+    m_darkReaderMaskCache[pageNum] = entry;
+}
+
+bool PDFGenerator::renderWithDarkReaderMask(Okular::PixmapRequest *request, double dpiX, double dpiY, QImage *outImage)
+{
+    ensureDarkReaderMask(request->page(), dpiX, dpiY);
+
+    if (request->isTile() || request->partialUpdatesWanted()) {
+        return false;
+    }
+
+    if (documentHasPassword || documentFilePath.isEmpty()) {
+        return false;
+    }
+
+    if (!m_darkReaderRenderer) {
+        m_darkReaderRenderer = DarkReaderRenderer::create(documentFilePath);
+    }
+    if (!m_darkReaderRenderer) {
+        return false;
+    }
+
+    QImage mask;
+    if (!m_darkReaderRenderer->render(request->page()->number(), dpiX, dpiY, outImage, &mask)) {
+        m_darkReaderRenderer.reset();
+        m_darkReaderMaskCache.remove(request->page()->number());
+        return false;
+    }
+
+    DarkReaderMaskEntry entry;
+    entry.mask = mask;
+    entry.dpiX = dpiX;
+    entry.dpiY = dpiY;
+    m_darkReaderMaskCache[request->page()->number()] = entry;
+
+    return true;
+}
+#endif
 
 template<typename PopplerLinkType, typename OkularLinkType, typename PopplerAnnotationType, typename OkularAnnotationType>
 void resolveMediaLinks(Okular::Action *action, enum Okular::Annotation::SubType subType, QHash<Okular::Annotation *, Poppler::Annotation *> &annotationsHash)
@@ -1710,6 +1805,20 @@ QVariant PDFGenerator::metaData(const QString &key, const QVariant &option) cons
         }
     } else if (key == QLatin1String("DocumentHasPassword")) {
         return documentHasPassword ? QStringLiteral("yes") : QStringLiteral("no");
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+    } else if (key == QLatin1String("NoRecolorMask")) {
+        // Used by PagePainter to fetch the exact "exclude from recoloring"
+        // mask generated for a page by the Dark Reader render path (see
+        // renderWithDarkReaderMask() and darkreaderoutputdev.h). option is
+        // the (int) page number; returns an invalid QVariant when no mask is
+        // available for that page (Dark Reader inactive, non-PDF-core-backed
+        // build, or the page has simply not been rendered with a mask yet),
+        // in which case callers must fall back to recoloring the whole page.
+        const auto it = m_darkReaderMaskCache.constFind(option.toInt());
+        if (it != m_darkReaderMaskCache.constEnd()) {
+            return QVariant::fromValue(it.value().mask);
+        }
+#endif
     }
     return QVariant();
 }

--- a/generators/poppler/generator_pdf.cpp
+++ b/generators/poppler/generator_pdf.cpp
@@ -799,7 +799,11 @@ Okular::Document::OpenResult PDFGenerator::init(QList<Okular::Page *> &pagesVect
     reparseConfig();
 
     // create annotation proxy
-    annotProxy = new PopplerAnnotationProxy(pdfdoc.get(), userMutex(), &annotationsOnOpenHash);
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+    annotProxy = new PopplerAnnotationProxy(pdfdoc.get(), userMutex(), &annotationsOnOpenHash, &m_pagesWithUnsavedAnnotations);
+#else
+    annotProxy = new PopplerAnnotationProxy(pdfdoc.get(), userMutex(), &annotationsOnOpenHash, nullptr);
+#endif
 
     setAdditionalDocumentAction(Okular::Document::CloseDocument, createLinkFromPopplerLink(pdfdoc->additionalAction(Poppler::Document::CloseDocument)));
     setAdditionalDocumentAction(Okular::Document::SaveDocumentStart, createLinkFromPopplerLink(pdfdoc->additionalAction(Poppler::Document::SaveDocumentStart)));
@@ -875,6 +879,7 @@ bool PDFGenerator::doCloseDocument()
 #if HAVE_POPPLER_CORE_OUTPUTDEV
     m_darkReaderRenderer.reset();
     m_darkReaderMaskCache.clear();
+    m_pagesWithUnsavedAnnotations.clear();
 #endif
 
     return true;
@@ -1427,6 +1432,10 @@ bool PDFGenerator::renderWithDarkReaderMask(Okular::PixmapRequest *request, doub
     }
 
     if (documentHasPassword || documentFilePath.isEmpty()) {
+        return false;
+    }
+
+    if (m_pagesWithUnsavedAnnotations.contains(request->page()->number())) {
         return false;
     }
 
@@ -2240,6 +2249,10 @@ bool PDFGenerator::save(const QString &fileName, SaveOptions options, QString *e
             // the default text message is good for this case
             break;
         }
+    } else {
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+        m_pagesWithUnsavedAnnotations.clear();
+#endif
     }
     return success;
 }

--- a/generators/poppler/generator_pdf.h
+++ b/generators/poppler/generator_pdf.h
@@ -29,6 +29,10 @@
 
 #include <unordered_map>
 
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+#include "darkreaderoutputdev.h"
+#endif
+
 class PDFOptionsPage;
 class PopplerAnnotationProxy;
 
@@ -171,6 +175,47 @@ private:
     bool documentHasPassword = false;
     QHash<int, Okular::Action *> m_additionalDocumentActions;
     void setAdditionalDocumentAction(Okular::Document::DocumentAdditionalActionType type, Okular::Action *action);
+
+#if HAVE_POPPLER_CORE_OUTPUTDEV
+    // BEGIN Dark Reader exact image mask
+    // Renders a page via a custom Poppler core OutputDev that additionally
+    // records exactly which pixels belong to embedded raster images, so
+    // that PagePainter's Dark Reader recoloring can leave them untouched.
+    // Only attempted for PDFs opened from a local file path, with no
+    // password (see darkreaderoutputdev.h for why). Returns false if the
+    // mask-aware render could not be produced for any reason; callers must
+    // fall back to the normal renderToImage() path in that case.
+    bool renderWithDarkReaderMask(Okular::PixmapRequest *request, double dpiX, double dpiY, QImage *outImage);
+
+    // Makes sure m_darkReaderMaskCache has a valid mask for @p page at the
+    // given resolution, generating one via DarkReaderRenderer if needed —
+    // regardless of whether the pixmap request that triggered this call is
+    // itself eligible to reuse the accompanying bitmap (tile/partial requests
+    // are not, but should still be able to prime the mask cache). No-op if a
+    // matching mask is already cached.
+    void ensureDarkReaderMask(const Okular::Page *page, double dpiX, double dpiY);
+
+    // Secondary, independent PDFDoc used only to drive Dark Reader's
+    // mask-generating renders (see darkreaderoutputdev.h for why a second
+    // document is needed at all). Created lazily on first use and kept
+    // around for as long as it keeps succeeding; reset whenever it fails so
+    // the next attempt can retry from scratch (e.g. if the file was briefly
+    // unavailable).
+    std::unique_ptr<DarkReaderRenderer> m_darkReaderRenderer;
+
+    // Most recently generated "exclude from recoloring" mask per page
+    // number, in the same (unrotated) orientation as the page bitmap. Reset
+    // whenever the document is closed. Deliberately not resized/rotated
+    // proactively: PagePainter adapts it to the current view geometry when
+    // it is consumed, the same way it already adapts the cached pixmap.
+    struct DarkReaderMaskEntry {
+        QImage mask;
+        double dpiX = 0;
+        double dpiY = 0;
+    };
+    QHash<int, DarkReaderMaskEntry> m_darkReaderMaskCache;
+    // END Dark Reader exact image mask
+#endif
 };
 
 #endif

--- a/generators/poppler/generator_pdf.h
+++ b/generators/poppler/generator_pdf.h
@@ -18,6 +18,7 @@
 
 #include <QBitArray>
 #include <QPointer>
+#include <QSet>
 
 #include <core/annotations.h>
 #include <core/document.h>
@@ -214,6 +215,7 @@ private:
         double dpiY = 0;
     };
     QHash<int, DarkReaderMaskEntry> m_darkReaderMaskCache;
+    QSet<int> m_pagesWithUnsavedAnnotations;
     // END Dark Reader exact image mask
 #endif
 };

--- a/gui/pagepainter.cpp
+++ b/gui/pagepainter.cpp
@@ -23,6 +23,8 @@
 
 // local includes
 #include "core/annotations.h"
+#include "core/document.h"
+#include "core/document_p.h"
 #include "core/observer.h"
 #include "core/page.h"
 #include "core/page_p.h"
@@ -43,6 +45,62 @@ inline QPen buildPen(const Okular::Annotation *ann, double width, const QColor &
     c.setAlphaF(ann->style().opacity());
     QPen p(QBrush(c), width, ann->style().lineStyle() == Okular::Annotation::Dashed ? Qt::DashLine : Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin);
     return p;
+}
+
+/**
+ * Fetches the "exclude from recoloring" mask a generator may have produced
+ * for @p page (currently: the PDF generator's Dark Reader render path; see
+ * PDFGenerator::metaData()'s "NoRecolorMask" key), and adapts it to line up
+ * pixel-for-pixel with the region about to be painted.
+ *
+ * @p fullPageDeviceSize is the size, in device pixels, of the full
+ * (uncropped) page at the current zoom level; @p deviceRectInFullPage is the
+ * sub-rectangle of that full page, also in device pixels, that is actually
+ * being painted right now (i.e. what \c backImage covers). Both mirror
+ * exactly how the page pixmap itself is scaled and cropped a few lines below.
+ *
+ * Returns a null QImage if no mask is available, e.g. because the document
+ * is not a PDF, Dark Reader has not rendered this page yet, or Okular was
+ * built without Poppler's core library headers. Callers must treat a null
+ * mask as "nothing is excluded", not as an error.
+ */
+static QImage fetchNoRecolorMask(const Okular::Page *page, const QSize &fullPageDeviceSize, const QRect &deviceRectInFullPage)
+{
+    if (!page || fullPageDeviceSize.isEmpty() || deviceRectInFullPage.isEmpty()) {
+        return QImage();
+    }
+
+    Okular::PagePrivate *pageP = Okular::PagePrivate::get(const_cast<Okular::Page *>(page));
+    if (!pageP || !pageP->m_doc || !pageP->m_doc->m_parent) {
+        return QImage();
+    }
+
+    const QVariant maskVariant = pageP->m_doc->m_parent->metaData(QStringLiteral("NoRecolorMask"), page->number());
+    if (!maskVariant.canConvert<QImage>()) {
+        return QImage();
+    }
+
+    QImage mask = maskVariant.value<QImage>();
+    if (mask.isNull()) {
+        return QImage();
+    }
+
+    // The mask was generated at the same nominal resolution as the pixmap
+    // request that produced it, which will not always exactly match the
+    // page's current on-screen size (e.g. a cached pixmap from a slightly
+    // different zoom level being reused momentarily). Scale and crop it
+    // exactly like the page pixmap itself is scaled and cropped, so it lines
+    // up with the image being recolored.
+    if (mask.size() != fullPageDeviceSize) {
+        mask = mask.scaled(fullPageDeviceSize);
+    }
+
+    const QRect clampedRect = deviceRectInFullPage.intersected(QRect(QPoint(0, 0), fullPageDeviceSize));
+    if (clampedRect.isEmpty()) {
+        return QImage();
+    }
+
+    return mask.copy(clampedRect);
 }
 
 void PagePainter::paintPageOnPainter(QPainter *destPainter, const Okular::Page *page, Okular::DocumentObserver *observer, int flags, int scaledWidth, int scaledHeight, const QRect limits)
@@ -92,6 +150,9 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
             break;
         case Okular::SettingsCore::EnumRenderMode::Recolor:
             backgroundColor = Okular::Settings::recolorBackground();
+            break;
+        case Okular::SettingsCore::EnumRenderMode::DarkReader:
+            backgroundColor = QColor(0x31, 0x36, 0x3b);
             break;
         default:;
         }
@@ -316,6 +377,15 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
             case Okular::SettingsCore::EnumRenderMode::HueShiftNegative:
                 hueShiftNegative(&backImage);
                 break;
+            case Okular::SettingsCore::EnumRenderMode::DarkReader: {
+                // Text color #eff0f1, background color #31363b. Embedded raster
+                // images are left untouched, using an exact per-pixel mask
+                // provided by the generator when available (currently: PDF
+                // only), falling back to recoloring the whole page otherwise.
+                const QImage noRecolorMask = fetchNoRecolorMask(page, QSize(dScaledWidth, dScaledHeight), dLimitsInPixmap);
+                recolorExcludingMask(&backImage, QColor(0xef, 0xf0, 0xf1), QColor(0x31, 0x36, 0x3b), noRecolorMask);
+                break;
+            }
             }
         }
 
@@ -332,7 +402,8 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
                     compMode = QPainter::CompositionMode_Difference;
                     break;
                 case Okular::SettingsCore::EnumRenderMode::Inverted: // fall through
-                case Okular::SettingsCore::EnumRenderMode::Recolor:
+                case Okular::SettingsCore::EnumRenderMode::Recolor:  // fall through
+                case Okular::SettingsCore::EnumRenderMode::DarkReader:
                     // CompositionMode_Multiply makes highlights invisible when background
                     // color is close to dark
                     compMode = QPainter::CompositionMode_Difference;
@@ -693,6 +764,51 @@ void PagePainter::recolor(QImage *image, const QColor &foreground, const QColor 
 
         const unsigned a = qAlpha(data[i]);
         data[i] = qRgba(r, g, b, a);
+    }
+}
+
+void PagePainter::recolorExcludingMask(QImage *image, const QColor &foreground, const QColor &background, const QImage &noRecolorMask)
+{
+    if (noRecolorMask.isNull()) {
+        recolor(image, foreground, background);
+        return;
+    }
+
+    if (image->format() != QImage::Format_ARGB32_Premultiplied) {
+        qCWarning(OkularUiDebug) << "Wrong image format! Converting...";
+        *image = image->convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    }
+
+    Q_ASSERT(image->format() == QImage::Format_ARGB32_Premultiplied);
+
+    if (noRecolorMask.size() != image->size()) {
+        // Geometry mismatch: whoever produced the mask did not adapt it to
+        // match this image (see fetchNoRecolorMask()). Rather than recolor
+        // the wrong pixels, fall back to plain recolor() for this frame.
+        qCWarning(OkularUiDebug) << "noRecolorMask size does not match image size, ignoring it";
+        recolor(image, foreground, background);
+        return;
+    }
+
+    // Keep a copy of the original (pre-recolor) pixels so they can be
+    // restored under the mask below. QImage's implicit sharing makes this
+    // cheap: no actual pixel data is copied unless/until 'image' is modified.
+    const QImage original = *image;
+
+    recolor(image, foreground, background);
+
+    const QImage mask = noRecolorMask.format() == QImage::Format_Grayscale8 ? noRecolorMask : noRecolorMask.convertToFormat(QImage::Format_Grayscale8);
+
+    QRgb *data = reinterpret_cast<QRgb *>(image->bits());
+    const QRgb *originalData = reinterpret_cast<const QRgb *>(original.constBits());
+
+    for (int y = 0, i = 0; y < image->height(); ++y) {
+        const uchar *maskRow = mask.constScanLine(y);
+        for (int x = 0; x < image->width(); ++x, ++i) {
+            if (maskRow[x] >= 128) {
+                data[i] = originalData[i];
+            }
+        }
     }
 }
 

--- a/gui/pagepainter.cpp
+++ b/gui/pagepainter.cpp
@@ -378,12 +378,25 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
                 hueShiftNegative(&backImage);
                 break;
             case Okular::SettingsCore::EnumRenderMode::DarkReader: {
-                // Text color #eff0f1, background color #31363b. Embedded raster
+                // Text color #eff0f1, background color #232627 (default) or config-driven. Embedded raster
                 // images are left untouched, using an exact per-pixel mask
                 // provided by the generator when available (currently: PDF
                 // only), falling back to recoloring the whole page otherwise.
+                QColor bgColor;
+                switch (Okular::Settings::darkReaderBackgroundMode()) {
+                case Okular::Settings::EnumDarkReaderBackgroundMode::ColorScheme:
+                    bgColor = QApplication::palette().color(QPalette::Active, QPalette::Window);
+                    break;
+                case Okular::Settings::EnumDarkReaderBackgroundMode::Custom:
+                    bgColor = Okular::Settings::darkReaderCustomBackgroundColor();
+                    break;
+                case Okular::Settings::EnumDarkReaderBackgroundMode::Default:
+                default:
+                    bgColor = QColor(0x23, 0x26, 0x27);
+                    break;
+                }
                 const QImage noRecolorMask = fetchNoRecolorMask(page, QSize(dScaledWidth, dScaledHeight), dLimitsInPixmap);
-                recolorExcludingMask(&backImage, QColor(0xef, 0xf0, 0xf1), QColor(0x31, 0x36, 0x3b), noRecolorMask);
+                recolorExcludingMask(&backImage, QColor(0xef, 0xf0, 0xf1), bgColor, noRecolorMask);
                 break;
             }
             }

--- a/gui/pagepainter.cpp
+++ b/gui/pagepainter.cpp
@@ -199,6 +199,7 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
     // make this a qcolor, rect map, since we don't need
     // to know s_id here! we are only drawing this right?
     QList<QPair<QColor, Okular::NormalizedRect>> bufferedHighlights;
+    QList<Okular::NormalizedRect> bufferedTextSelections;
     QList<Okular::Annotation *> bufferedAnnotations;
     QList<Okular::Annotation *> unbufferedAnnotations;
     Okular::Annotation *boundingRectOnlyAnn = nullptr; // Paint the bounding rect of this annotation
@@ -224,7 +225,7 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
             const Okular::RegularAreaRect *textSelection = page->textSelection();
             for (const auto &rect : std::as_const(*textSelection)) {
                 if (rect.intersects(limitRect)) {
-                    bufferedHighlights.append(qMakePair(page->textSelectionColor(), rect));
+                    bufferedTextSelections.append(rect);
                 }
             }
         }
@@ -274,7 +275,7 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
 
     /** 3 - ENABLE BACKBUFFERING IF DIRECT IMAGE MANIPULATION IS NEEDED **/
     const bool bufferAccessibility = (flags & Accessibility) && Okular::SettingsCore::changeColors() && (Okular::SettingsCore::renderMode() != Okular::SettingsCore::EnumRenderMode::Paper);
-    const bool useBackBuffer = bufferAccessibility || !bufferedHighlights.isEmpty() || !bufferedAnnotations.isEmpty() || viewPortPoint;
+    const bool useBackBuffer = bufferAccessibility || !bufferedHighlights.isEmpty() || !bufferedTextSelections.isEmpty() || !bufferedAnnotations.isEmpty() || viewPortPoint;
     QPixmap backPixmap; // order of declarations is important: ownedPainter should be destroyed before its pixmap
     std::unique_ptr<QPainter> ownedPainter;
     QPainter *mixedPainter = nullptr; // Will point to either a provided destPainter or the ownedPainter
@@ -438,6 +439,35 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
             const QRect frameRect = r.geometry(scaledWidth, scaledHeight).translated(-scaledCrop.topLeft()).translated(-limits.left(), -limits.top());
             painter.setPen(frameColor);
             painter.drawRect(frameRect);
+        }
+
+        // draw text selections that are inside the 'limits' paint region
+        if (!bufferedTextSelections.isEmpty()) {
+            QPainter::CompositionMode compMode = QPainter::CompositionMode_Multiply;
+            QColor highlightColor = page->textSelectionColor();
+            QColor frameColor = highlightColor.darker(150);
+            if (Okular::SettingsCore::changeColors()) {
+                if (Okular::SettingsCore::renderMode() == Okular::SettingsCore::EnumRenderMode::Paper) {
+                    compMode = QPainter::CompositionMode_Difference;
+                } else {
+                    compMode = QPainter::CompositionMode_Screen;
+                    frameColor.setRgb((frameColor.red() - 255) * -1, (frameColor.green() - 255) * -1, (frameColor.blue() - 255) * -1);
+                }
+            }
+
+            for (const auto &r : std::as_const(bufferedTextSelections)) {
+                // find out the rect to highlight on pixmap
+                QRect highlightRect = r.geometry(scaledWidth, scaledHeight).translated(-scaledCrop.topLeft()).intersected(limits);
+                highlightRect.translate(-limits.left(), -limits.top());
+
+                QPainter painter(&backImage);
+                painter.setCompositionMode(compMode);
+                painter.fillRect(highlightRect, highlightColor);
+
+                const QRect frameRect = r.geometry(scaledWidth, scaledHeight).translated(-scaledCrop.topLeft()).translated(-limits.left(), -limits.top());
+                painter.setPen(frameColor);
+                painter.drawRect(frameRect);
+            }
         }
 
         // 4B.4. paint annotations [COMPOSITED ONES]

--- a/gui/pagepainter.cpp
+++ b/gui/pagepainter.cpp
@@ -490,7 +490,7 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
                     switch (hlType) {
                     // highlight the whole rect
                     case Okular::HighlightAnnotation::Highlight:
-                        drawShapeOnImage(backImage, path, true, Qt::NoPen, acolor, pageScale, Multiply);
+                        drawShapeOnImage(backImage, path, true, Qt::NoPen, acolor, pageScale, Okular::SettingsCore::changeColors() ? Normal : Multiply);
                         break;
                     // highlight the bottom part of the rect
                     case Okular::HighlightAnnotation::Squiggly:
@@ -498,7 +498,7 @@ void PagePainter::paintCroppedPageOnPainter(QPainter *destPainter,
                         path[3].y = (path[0].y + path[3].y) / 2.0;
                         path[2].x = (path[1].x + path[2].x) / 2.0;
                         path[2].y = (path[1].y + path[2].y) / 2.0;
-                        drawShapeOnImage(backImage, path, true, Qt::NoPen, acolor, pageScale, Multiply);
+                        drawShapeOnImage(backImage, path, true, Qt::NoPen, acolor, pageScale, Okular::SettingsCore::changeColors() ? Normal : Multiply);
                         break;
                     // make a line at 3/4 of the height
                     case Okular::HighlightAnnotation::Underline:
@@ -768,15 +768,40 @@ void PagePainter::recolor(QImage *image, const QColor &foreground, const QColor 
     QRgb *data = reinterpret_cast<QRgb *>(image->bits());
     const int pixels = image->width() * image->height();
 
+    const bool isDarkMode = qGray(background.rgb()) < qGray(foreground.rgb());
+
     for (int i = 0; i < pixels; ++i) {
-        const int lightness = qGray(data[i]);
+        const uchar r_orig = qRed(data[i]);
+        const uchar g_orig = qGreen(data[i]);
+        const uchar b_orig = qBlue(data[i]);
 
-        const float r = scaleRed * lightness + foreground_red;
-        const float g = scaleGreen * lightness + foreground_green;
-        const float b = scaleBlue * lightness + foreground_blue;
+        const int max_val = qMax(r_orig, qMax(g_orig, b_orig));
+        const int min_val = qMin(r_orig, qMin(g_orig, b_orig));
 
-        const unsigned a = qAlpha(data[i]);
-        data[i] = qRgba(r, g, b, a);
+        if (max_val - min_val > 20) {
+            // Colored pixel (e.g. highlight, underline, links)
+            const unsigned a = qAlpha(data[i]);
+            if (isDarkMode) {
+                uchar R = r_orig;
+                uchar G = g_orig;
+                uchar B = b_orig;
+                invertLumaPixel(R, G, B, 0.2126, 0.7152, 0.0722); // sRGB luma coefficients
+                data[i] = qRgba(R, G, B, a);
+            } else {
+                // Keep original color in light modes
+                data[i] = qRgba(r_orig, g_orig, b_orig, a);
+            }
+        } else {
+            // Neutral pixel (text, background, grayscale)
+            const int lightness = qGray(data[i]);
+
+            const float r = scaleRed * lightness + foreground_red;
+            const float g = scaleGreen * lightness + foreground_green;
+            const float b = scaleBlue * lightness + foreground_blue;
+
+            const unsigned a = qAlpha(data[i]);
+            data[i] = qRgba(r, g, b, a);
+        }
     }
 }
 

--- a/gui/pagepainter.h
+++ b/gui/pagepainter.h
@@ -102,6 +102,23 @@ private:
      * Shifts hue of each pixel by 240 degrees, by simply swapping channels.
      */
     static void hueShiftNegative(QImage *image);
+    /**
+     * Applies recolor() to @p image (mapping black to @p foreground and white
+     * to @p background), then restores the original pixel value wherever
+     * @p noRecolorMask says the pixel should be excluded from recoloring.
+     *
+     * @p noRecolorMask is a Format_Grayscale8 image the same size as @p image,
+     * where 255 means "leave this pixel untouched" and 0 means "recolor it
+     * normally"; if it is null, this behaves exactly like recolor().
+     *
+     * Used by Dark Reader mode to recolor page text/background while leaving
+     * embedded raster images untouched. Unlike a heuristic based on the
+     * rendered pixels' own colors, @p noRecolorMask is expected to come from
+     * exact per-pixel provenance information recorded while rendering (see
+     * the PDF generator's use of its custom Poppler OutputDev), so it is not
+     * fooled by grayscale or muted-color photos.
+     */
+    static void recolorExcludingMask(QImage *image, const QColor &foreground, const QColor &background, const QImage &noRecolorMask);
     // END Change Colors feature
 
     // my pretty dear raster function

--- a/part/colormodemenu.cpp
+++ b/part/colormodemenu.cpp
@@ -109,16 +109,20 @@ void ColorModeMenu::slotConfigChanged()
     // Check the current color mode action, and update the toolbar button default action
     const int rm = Okular::SettingsCore::renderMode();
     const QList<QAction *> colorModeActions = m_colorModeActionGroup->actions();
+    bool modeFound = false;
     for (QAction *a : colorModeActions) {
         if (a != m_aNormal && a->data().toInt() == rm) {
             a->setChecked(true);
             setDefaultAction(a);
+            modeFound = true;
             break;
         }
     }
 
-    // If Change Colors is disabled, check Normal Colors instead
-    if (!Okular::SettingsCore::changeColors()) {
+    // If Change Colors is disabled, or the current render mode is not one of this menu's
+    // own modes (e.g. it is controlled by another feature such as Dark Reader),
+    // check Normal Colors instead.
+    if (!Okular::SettingsCore::changeColors() || !modeFound) {
         m_aNormal->setChecked(true);
     }
 

--- a/part/dlgaccessibility.cpp
+++ b/part/dlgaccessibility.cpp
@@ -66,6 +66,7 @@ DlgAccessibility::DlgAccessibility(QWidget *parent)
     colorMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Invert luma (symmetric)"));
     colorMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Shift hue positive"));
     colorMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Shift hue negative"));
+    colorMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Dark Reader"));
     colorMode->setObjectName(QStringLiteral("kcfg_RenderMode"));
     layout->addRow(i18nc("@label:listbox Config dialog, accessibility page", "Color mode:"), colorMode);
 

--- a/part/dlgaccessibility.cpp
+++ b/part/dlgaccessibility.cpp
@@ -130,6 +130,29 @@ DlgAccessibility::DlgAccessibility(QWidget *parent)
     m_colorModeConfigStack->addWidget(pageWidget);
     // END Convert to black & white page
 
+    // BEGIN Dark Reader page
+    pageWidget = new QWidget(this);
+    pageLayout = new QFormLayout(pageWidget);
+
+    QComboBox *drBackgroundMode = new QComboBox(this);
+    drBackgroundMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Default"));
+    drBackgroundMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "From color scheme"));
+    drBackgroundMode->addItem(i18nc("@item:inlistbox Config dialog, accessibility page", "Custom"));
+    drBackgroundMode->setObjectName(QStringLiteral("kcfg_DarkReaderBackgroundMode"));
+    pageLayout->addRow(i18nc("@label:listbox Config dialog, accessibility page", "Background color:"), drBackgroundMode);
+
+    KColorButton *drCustomColor = new KColorButton(this);
+    drCustomColor->setObjectName(QStringLiteral("kcfg_DarkReaderCustomBackgroundColor"));
+    pageLayout->addRow(i18nc("@label:chooser Config dialog, accessibility page", "Custom background color:"), drCustomColor);
+
+    m_colorModeConfigStack->addWidget(pageWidget);
+
+    connect(drBackgroundMode, qOverload<int>(&QComboBox::currentIndexChanged), this, [drCustomColor](int index) {
+        drCustomColor->setEnabled(index == 2);
+    });
+    drCustomColor->setEnabled(drBackgroundMode->currentIndex() == 2);
+    // END Dark Reader page
+
     layout->addRow(QString(), m_colorModeConfigStack);
 
     // Setup controls enabled states:
@@ -192,6 +215,8 @@ void DlgAccessibility::slotColorModeSelected(int mode)
         m_colorModeConfigStack->setCurrentIndex(2);
     } else if (mode == Okular::Settings::EnumRenderMode::BlackWhite) {
         m_colorModeConfigStack->setCurrentIndex(3);
+    } else if (mode == Okular::Settings::EnumRenderMode::DarkReader) {
+        m_colorModeConfigStack->setCurrentIndex(4);
     } else {
         m_colorModeConfigStack->setCurrentIndex(0);
     }

--- a/part/part.cpp
+++ b/part/part.cpp
@@ -50,6 +50,7 @@
 #include <QPrinter>
 #include <QScopedValueRollback>
 #include <QScrollBar>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QSpinBox>
 #include <QStandardPaths>
@@ -746,6 +747,7 @@ void Part::setupViewerActions()
     m_showLeftPanel = nullptr;
     m_showBottomBar = nullptr;
     m_showSignaturePanel = nullptr;
+    m_darkReaderAction = nullptr;
 
     m_showProperties = ac->addAction(QStringLiteral("properties"));
     m_showProperties->setText(i18n("&Properties"));
@@ -961,6 +963,18 @@ void Part::setupActions()
     QAction *playPauseAction = new QAction(i18n("Play/Pause Presentation"), ac);
     ac->addAction(QStringLiteral("presentation_play_pause"), playPauseAction);
     playPauseAction->setEnabled(false);
+
+    // Dark Reader: inverts text and background colors (using a dark gray/off-white palette
+    // instead of pure black/white) while leaving images untouched. Currently only supported
+    // for PDF documents; see updateViewActions().
+    m_darkReaderAction = ac->add<KToggleAction>(QStringLiteral("dark_reader_mode"));
+    m_darkReaderAction->setText(i18nc("@action:inmenu, toggles the dark color scheme for the document", "Dark Reader"));
+    m_darkReaderAction->setIcon(QIcon::fromTheme(QStringLiteral("view-dark-mode"), QIcon::fromTheme(QStringLiteral("weather-clear-night"))));
+    m_darkReaderAction->setWhatsThis(i18n("Toggles a dark color scheme for the document: text is drawn light on a dark background, while images are left unaffected."));
+    connect(m_darkReaderAction, &QAction::toggled, this, &Part::slotToggleDarkReader);
+    connect(Okular::SettingsCore::self(), &Okular::SettingsCore::colorModesChanged, this, &Part::slotUpdateDarkReaderAction);
+    m_darkReaderAction->setEnabled(false);
+    slotUpdateDarkReaderAction();
 }
 
 Part::~Part()
@@ -2030,6 +2044,29 @@ void Part::slotShowBottomBar()
     m_bottomBar->setVisible(showBottom);
 }
 
+void Part::slotToggleDarkReader()
+{
+    const bool enabled = m_darkReaderAction->isChecked();
+    if (enabled) {
+        Okular::SettingsCore::setRenderMode(Okular::SettingsCore::EnumRenderMode::DarkReader);
+    }
+    Okular::SettingsCore::setChangeColors(enabled);
+    Okular::SettingsCore::self()->save();
+}
+
+void Part::slotUpdateDarkReaderAction()
+{
+    if (!m_darkReaderAction) {
+        return;
+    }
+
+    const bool enabled = Okular::SettingsCore::changeColors() && Okular::SettingsCore::renderMode() == Okular::SettingsCore::EnumRenderMode::DarkReader;
+    if (m_darkReaderAction->isChecked() != enabled) {
+        QSignalBlocker blocker(m_darkReaderAction);
+        m_darkReaderAction->setChecked(enabled);
+    }
+}
+
 void Part::slotFileDirty(const QString &path)
 {
     // The beauty of this is that each start cancels the previous one.
@@ -2255,6 +2292,16 @@ void Part::updateViewActions()
         }
     }
     Q_EMIT viewerMenuStateChange(opened);
+
+    if (m_darkReaderAction) {
+        // Dark Reader is currently only supported for PDF documents.
+        const QString mimeTypeName = opened ? m_document->documentInfo().get(DocumentInfo::MimeType) : QString();
+        const bool isPdf = mimeTypeName == QLatin1String("application/pdf");
+        m_darkReaderAction->setEnabled(opened && isPdf);
+        if (!isPdf && m_darkReaderAction->isChecked()) {
+            m_darkReaderAction->setChecked(false);
+        }
+    }
 
     updateBookmarksActions();
 }

--- a/part/part.h
+++ b/part/part.h
@@ -243,6 +243,8 @@ protected Q_SLOTS:
     void slotShowBottomBar();
     void slotShowPresentation();
     void slotHidePresentation();
+    void slotToggleDarkReader();
+    void slotUpdateDarkReaderAction();
 
     /**
      * Updates the menu that is by default at the right end of the toolbar.
@@ -437,6 +439,7 @@ private:
     KToggleAction *m_showMenuBarAction;
     KToggleAction *m_showLeftPanel;
     KToggleAction *m_showBottomBar;
+    KToggleAction *m_darkReaderAction;
     QAction *m_showSignaturePanel;
     KToggleFullScreenAction *m_showFullScreenAction;
     QAction *m_aboutBackend;

--- a/part/part.rc
+++ b/part/part.rc
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE gui SYSTEM "kpartgui.dtd">
-<gui name="okular_part" version="56">
+<gui name="okular_part" version="57">
 <MenuBar>
   <Menu name="file"><text>&amp;File</text>
     <Action name="get_new_stuff" group="file_open"/>
@@ -100,6 +100,7 @@
   <Menu name="help"><text>&amp;Help</text>
     <Action name="help_about_backend" group="about_merge"/>
   </Menu>
+  <Action name="dark_reader_mode"/>
 </MenuBar>
 <ToolBar name="mainToolBar"><text>Main Toolbar</text>
   <Action name="show_leftpanel"/>


### PR DESCRIPTION
# Add experimental Dark Reader mode for PDF documents 
## [Demo](https://www.youtube.com/watch?v=Xf0qtwL_RVU&feature=youtu.be)

## Summary

This PR introduces an experimental **Dark Reader** mode for PDF documents in Okular. Unlike the existing inverted color modes, it attempts to preserve images while adapting document colors for dark viewing.

### What's included

* Add a new **Dark Reader** render mode for PDF documents.
* Add a dedicated toggle action and integrate it with the existing rendering/configuration pipeline.
* Add configuration options for the Dark Reader background:

  * Default
  * Follow color scheme
  * Custom color
* Preserve unsaved annotations while Dark Reader is enabled.
* Preserve text selection visibility in dark rendering.
* Update the README with feature details and a demo link.

## Implementation notes

The implementation reuses Okular's existing rendering and configuration infrastructure as much as possible instead of introducing a separate rendering pipeline.

One issue encountered during development was that the secondary Poppler document used for generating the no-recolor mask does not contain unsaved in-memory annotations. To avoid disappearing annotations, pages with unsaved annotation changes are rendered from the primary document while still generating the mask to preserve image protection.

## Feedback requested

I'm relatively new to the C++/Qt/KDE ecosystem, so I'd especially appreciate feedback on:

* Overall architecture and whether this approach fits Okular's design.
* C++/Qt best practices I may have missed.
* Poppler or rendering-related concerns.
* Performance implications or opportunities for simplification.
* Any KDE coding conventions or patterns I should follow.

I also want to be transparent that I used LLMs extensively during development for implementation assistance and explorationlimited familiarity with this codebase and ecosystem, I'd really appreciate careful review and suggestions for improving the implementation.
